### PR TITLE
Update Dockerfile - add fonts-droid-fallback for cjk languages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY rootfs/ /
 SHELL ["/bin/bash", "-c"]
 
 RUN	apt-get update && \
-	apt-get install -y tzdata ca-certificates supervisor curl wget python3 python3-pip sed unzip xvfb x11vnc websockify openbox libnss3 libgbm-dev libasound2 && \
+	apt-get install -y tzdata ca-certificates supervisor curl wget python3 python3-pip sed unzip xvfb x11vnc websockify openbox libnss3 libgbm-dev libasound2 fonts-droid-fallback && \
 #Chromium
 	wget https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/1003039/chrome-linux.zip -P /tmp && \
 	unzip /tmp/chrome-linux.zip -d /opt && \


### PR DESCRIPTION
current dockerfile does not install cjk fonts(Chinese, Japanese and Korea characters), after install droid-fallback font, East Asian languages should works as expected

original font rendering for baidu.com
![图片](https://github.com/vital987/chrome-novnc/assets/352727/8645e717-6f69-4d6e-88f7-60f395a759a5)

after font installed 
![图片](https://github.com/vital987/chrome-novnc/assets/352727/567f9f9e-3c20-4191-8210-f6ad2a350b34)
