### PR TITLE
add oneshot script to remove singletonlock and singletoncookie

### DIFF
--- a/assets/config/supervisor/5-remove-singleton.conf
+++ b/assets/config/supervisor/5-remove-singleton.conf
@@ -1,0 +1,4 @@
+[program:Chromium-Oneshot-Prepare]
+command=bash -c 'rm -f /root/.config/chromium/SingletonLock; rm -f /root/.config/chromium/SingletonLock;'
+priority=5
+stderr_logfile=/var/log/chromium.err.log

--- a/assets/config/supervisor/6-chromium.conf
+++ b/assets/config/supervisor/6-chromium.conf
@@ -1,5 +1,5 @@
 [program:Chromium]
 command=bash -c 'chromium --no-sandbox --test-type --disable-dev-shm-usage --disable-gpu --start-maximized'
-priority=5
+priority=6
 autorestart=true
 stderr_logfile=/var/log/chromium.err.log

--- a/assets/config/supervisor/7-self-ping.conf
+++ b/assets/config/supervisor/7-self-ping.conf
@@ -3,4 +3,4 @@ command=python3 /config/self-ping.py
 stderr_logfile=/var/log/selfping.err.log
 exitcodes=0
 startsecs=0
-priority=6
+priority=7


### PR DESCRIPTION
For persistent profiles via mounted volume to /root/.config/chromium
often the files SingletonLock and SingletonCookie remain as the container is not guaranteed to gracefully end chromium, these prevent startup of chromium.
also moved chromium and self-ping down the list so they happen after the oneshot script